### PR TITLE
Updated rospython_config

### DIFF
--- a/rospython_config
+++ b/rospython_config
@@ -8,25 +8,25 @@ keys=fileHandler,streamHandler
 keys=defaultFormatter
 
 [logger_root]
-level=DEBUG
+level=INFO
 handlers=fileHandler
 
 [logger_rosout]
-level=DEBUG
+level=INFO
 handlers=streamHandler
 propagate=1
 qualname=rosout
 
 [handler_fileHandler]
 class=handlers.RotatingFileHandler
-level=DEBUG
+level=INFO
 formatter=defaultFormatter
 # log filename, mode, maxBytes, backupCount
-args=(os.environ['ROS_LOG_FILENAME'], 'a', 5000000, 1)
+args=(os.environ['ROS_LOG_FILENAME'], 'a', 1000000, 1)
 
 [handler_streamHandler]
 class=rosgraph.roslogging.RosStreamHandler
-level=DEBUG
+level=INFO
 formatter=defaultFormatter
 # colorize output flag
 args=(False,)


### PR DESCRIPTION
Eliminate DEBUG level ROS log entries and rotate the log files at 1 MB.